### PR TITLE
fix minor bug for preset dataset

### DIFF
--- a/causal_graphs/graph_definition.py
+++ b/causal_graphs/graph_definition.py
@@ -245,7 +245,7 @@ class CausalDAGDataset(CausalDAG):
             data_int = data_int.astype(np.int32)
 
         if data_obs.dtype == np.int32:
-            num_categs = data_obs.max(axis=-1)
+            num_categs = data_obs.max(axis=0)
             new_dist = lambda i : CategoricalDist(num_categs[i]+1, None)
         elif data_obs.dtype == np.float32:
             new_dist = lambda i : ContinuousProbDist()


### PR DESCRIPTION
In order to **obtain the number of categories for each variable**, it should be obtained from the data_obs dimension of 0 😉